### PR TITLE
Single quote doesn't match double quote in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ apply plugin: 'net.vivin.gradle-semantic-build-versioning'
 **Gradle version >= 2.1**
 ```gradle
 plugins {
-    id "net.vivin.gradle-semantic-build-versioning" version: "2.0.2"
+    id "net.vivin.gradle-semantic-build-versioning" version "2.0.2"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ apply plugin: 'net.vivin.gradle-semantic-build-versioning'
 **Gradle version >= 2.1**
 ```gradle
 plugins {
-    id "net.vivin.gradle-semantic-build-versioning' version: "2.0.2"
+    id "net.vivin.gradle-semantic-build-versioning" version: "2.0.2"
 }
 ```
 


### PR DESCRIPTION
Mismatched quote type makes it harder to copy and paste the configuration instructions.